### PR TITLE
Use env var for nimble

### DIFF
--- a/issue280and524.nimble
+++ b/issue280and524.nimble
@@ -12,7 +12,7 @@ requires "nim >= 0.18.0"
 
 task setup, "Download and generate":
   let
-    nimble = getEnv("NIMBLE_TEST", "nimble")
+    nimble = getEnv("NIMBLE_TEST_BINARY_PATH", "nimble")
   exec nimble & " install https://github.com/nimble-test/issue280and524.git?subdir=generator -y"
   withDir thisDir():
     let cmd = when defined(windows): "cmd /c " else: ""

--- a/issue280and524.nimble
+++ b/issue280and524.nimble
@@ -10,15 +10,10 @@ srcDir        = "src"
 
 requires "nim >= 0.18.0"
 
-import strutils
-
 task setup, "Download and generate":
   let
-    dirSep = when defined(windows): "\\" else: "/"
-    path =
-      if selfExe().len == 0: ""
-      else: selfExe().rsplit(dirSep, maxsplit = 1)[0] & dirSep
-  exec path & "nimble install https://github.com/nimble-test/issue280and524.git?subdir=generator -y"
+    nimble = getEnv("NIMBLE_TEST", "nimble")
+  exec nimble & " install https://github.com/nimble-test/issue280and524.git?subdir=generator -y"
   withDir thisDir():
     let cmd = when defined(windows): "cmd /c " else: ""
     exec cmd & "generator"

--- a/issue280and524.nimble
+++ b/issue280and524.nimble
@@ -12,7 +12,8 @@ requires "nim >= 0.18.0"
 
 task setup, "Download and generate":
   let
-    nimble = getEnv("NIMBLE_TEST_BINARY_PATH", "nimble")
+    nimble = getEnv("NIMBLE_TEST_BINARY_PATH")
+  doAssert nimble.len != 0, "NIMBLE_TEST_BINARY_PATH not set"
   exec nimble & " install https://github.com/nimble-test/issue280and524.git?subdir=generator -y"
   withDir thisDir():
     let cmd = when defined(windows): "cmd /c " else: ""


### PR DESCRIPTION
Previous PR was just wrong - it finds the `nimble` binary for the active `nim e` which is still the broken `nimble`.

Instead, tester will now set the `NIMBLE_TEST` env var on startup which all child processes can use.